### PR TITLE
Remove backslash before pipe symbol so that the backslash does not show up on the web page

### DIFF
--- a/Appendix/Unix/UnixCheatSheet.md
+++ b/Appendix/Unix/UnixCheatSheet.md
@@ -148,7 +148,7 @@ header:
 |cmd `>>` <span style="color:Red">file</span>	|append output to file|
 |cmd `2>` <span style="color:Red">stderr</span>	|error output to file|
 |cmd `1>&2` <span style="color:Red">file</span>	|send output and error to file|
-|cmd1 `\|` <span style="color:Red">cmd2</span> 	|send output of cmd1 to cmd2|
+|cmd1 `|` <span style="color:Red">cmd2</span> 	|send output of cmd1 to cmd2|
 
 ## PRE-DECLARED VARIABLES
 


### PR DESCRIPTION
Removed backslash before pipe symbol because, unlike on Github, on the web page it actually shows up as \| instead of just |